### PR TITLE
empty xplbody

### DIFF
--- a/core/class/xpl.class.php
+++ b/core/class/xpl.class.php
@@ -178,6 +178,8 @@ class xPLCmd extends cmd {
                             }
                             $body = str_replace($replace, $replaceBy, $this->getConfiguration('xPLbody'));
                             break;
+                        default:
+                            $body = $this->getConfiguration('xPLbody');
                     }
                     break;
             }


### PR DESCRIPTION
In case of sending a "default action", xplbody is not filled.
I've tested this modification with an lighting.basic message successfully, with jeedom 1.212
Cordially.
